### PR TITLE
add support for customStyleFn in createStyleRenderer util

### DIFF
--- a/src/createStyleRenderer.js
+++ b/src/createStyleRenderer.js
@@ -19,8 +19,12 @@ const reduceStyles = (styleArray, stylesMap) => styleArray
 /**
  * Returns a styleRenderer from a customStyleMap and a wrapper callback (Component)
  */
-const createStyleRenderer = (wrapper, stylesMap) => (children, styleArray, params) => {
-  const style = reduceStyles(styleArray, stylesMap);
+const createStyleRenderer = (wrapper, stylesMap, customStyleFn) => (children, styleArray, params) => {
+  let style = reduceStyles(styleArray, stylesMap);
+  if(customStyleFn) {
+    const customStyles = customStyleFn(styleArray);
+    style = Object.assign(style, customStyles);
+  }
   return wrapper(Object.assign({}, { children }, params, { style }));
 };
 

--- a/src/render.js
+++ b/src/render.js
@@ -251,7 +251,7 @@ export const render = (raw, renderers = {}, options = {}) => {
     styles: stylesRenderer,
     decorators,
   } = renderers;
-  // If decorators are present, they are maped with the blocks array
+  // If decorators are present, they are mapped with the blocks array
   const blocksWithDecorators = decorators ? withDecorators(raw, decorators, options) : raw.blocks;
   // Nest blocks by depth
   const blocks = byDepth(blocksWithDecorators);


### PR DESCRIPTION
Implementation adopted/taken from [`draft-js`](https://github.com/facebook/draft-js/blob/126ce9938826848eefc49191e40630cdb83c9b39/src/component/contents/DraftEditorLeaf.react.js#L162). 

`redraft` relies heavily on the parsing/hierarchy from`draft-js` to parse the JSON output by [`convertToRaw`](https://draftjs.org/docs/api-reference-data-conversion/#converttoraw), so this addition for my use case is pretty trivial.


TODO

- [ ] unit tests
- [ ] build and symlink with Voyager