### PR TITLE
add customStyleFn as a redraft option

### DIFF
--- a/src/createStyleRenderer.js
+++ b/src/createStyleRenderer.js
@@ -19,8 +19,12 @@ const reduceStyles = (styleArray, stylesMap) => styleArray
 /**
  * Returns a styleRenderer from a customStyleMap and a wrapper callback (Component)
  */
-const createStyleRenderer = (wrapper, stylesMap) => (children, styleArray, params) => {
-  const style = reduceStyles(styleArray, stylesMap);
+const createStyleRenderer = (wrapper, stylesMap, customStyleFn) => (children, styleArray, params) => {
+  let style = reduceStyles(styleArray, stylesMap);
+  if(customStyleFn) {
+    const customStyles = customStyleFn(styleArray);
+    style = Object.assign(style, customStyles);
+  }
   return wrapper(Object.assign({}, { children }, params, { style }));
 };
 

--- a/src/createStyleRenderer.js
+++ b/src/createStyleRenderer.js
@@ -19,13 +19,18 @@ const reduceStyles = (styleArray, stylesMap) => styleArray
 /**
  * Returns a styleRenderer from a customStyleMap and a wrapper callback (Component)
  */
-const createStyleRenderer = (wrapper, stylesMap, customStyleFn) => (children, styleArray, params) => {
+const createStyleRenderer = (wrapper, stylesMap) => (children, styleArray, params) => {
   let style = reduceStyles(styleArray, stylesMap);
-  if(customStyleFn) {
-    const customStyles = customStyleFn(styleArray);
-    style = Object.assign(style, customStyles);
-  }
-  return wrapper(Object.assign({}, { children }, params, { style }));
+
+  return (customStyleFn) => {
+    if (customStyleFn && typeof customStyleFn === 'function') {
+      const customStyles = customStyleFn(styleArray);
+      style = Object.assign(style, customStyles);
+      console.log(style);
+    }
+
+    return wrapper(Object.assign({}, { children }, params, { style }));
+  };
 };
 
 export default createStyleRenderer;

--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -7,6 +7,7 @@ const defaultOptions = {
     split: true,
   },
   blockFallback: 'unstyled',
+  customStyleFn: undefined,
 };
 
 export default defaultOptions;

--- a/src/render.js
+++ b/src/render.js
@@ -251,7 +251,7 @@ export const render = (raw, renderers = {}, options = {}) => {
     styles: stylesRenderer,
     decorators,
   } = renderers;
-  // If decorators are present, they are maped with the blocks array
+  // If decorators are present, they are mapped with the blocks array
   const blocksWithDecorators = decorators ? withDecorators(raw, decorators, options) : raw.blocks;
   // Nest blocks by depth
   const blocks = byDepth(blocksWithDecorators);

--- a/src/render.js
+++ b/src/render.js
@@ -22,7 +22,7 @@ export const renderNode = (
   keyGenerator,
 ) => {
   if (node.styles && styleRenderers) {
-    return styleRenderers(checkJoin(node.content, options), node.styles, { key: keyGenerator() });
+    return styleRenderers(checkJoin(node.content, options), node.styles, { key: keyGenerator() })(options.customStyleFn);
   }
   let children = [];
   let index = 0;


### PR DESCRIPTION
This PR is a mashup of #1 and #2. If we're going to make `blockStyleFn` an option, `customStyleFn` should probably follow the same pattern.

After #2 and this commit are merged, `redraft` usage might look something like

```
import React from 'react';
import PropTypes from 'prop-types';
import redraft from 'redraft';
import renderers from './renderers';
import { blockStyleFn, customStyleFn } from './styling';

const Content = ({ rawContentState }) => (
  <React.Fragment>
    {redraft(rawContentState, renderers, { blockStyleFn, customStyleFn })}
  </React.Fragment>
);

export default Content;
```