### PR TITLE
add customStyleFn as a redraft option

### DIFF
--- a/src/createStyleRenderer.js
+++ b/src/createStyleRenderer.js
@@ -20,8 +20,17 @@ const reduceStyles = (styleArray, stylesMap) => styleArray
  * Returns a styleRenderer from a customStyleMap and a wrapper callback (Component)
  */
 const createStyleRenderer = (wrapper, stylesMap) => (children, styleArray, params) => {
-  const style = reduceStyles(styleArray, stylesMap);
-  return wrapper(Object.assign({}, { children }, params, { style }));
+  let style = reduceStyles(styleArray, stylesMap);
+
+  return (customStyleFn) => {
+    if (customStyleFn && typeof customStyleFn === 'function') {
+      const customStyles = customStyleFn(styleArray);
+      style = Object.assign(style, customStyles);
+      console.log(style);
+    }
+
+    return wrapper(Object.assign({}, { children }, params, { style }));
+  };
 };
 
 export default createStyleRenderer;

--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -8,6 +8,7 @@ const defaultOptions = {
   },
   blockFallback: 'unstyled',
   blockStyleFn: undefined,
+  customStyleFn: undefined
 };
 
 export default defaultOptions;

--- a/src/render.js
+++ b/src/render.js
@@ -22,7 +22,7 @@ export const renderNode = (
   keyGenerator,
 ) => {
   if (node.styles && styleRenderers) {
-    return styleRenderers(checkJoin(node.content, options), node.styles, { key: keyGenerator() });
+    return styleRenderers(checkJoin(node.content, options), node.styles, { key: keyGenerator() })(options.customStyleFn);
   }
   let children = [];
   let index = 0;


### PR DESCRIPTION
This PR is a mashup of #1 and #2. If we're going to make `blockStyleFn` an option, `customStyleFn` should probably follow the same pattern.

After #2 and this commit are merged, `redraft` usage might look something like

```
import React from 'react';
import PropTypes from 'prop-types';
import redraft from 'redraft';
import renderers from './renderers';
import { blockStyleFn, customStyleFn } from './styling';

const Content = ({ rawContentState }) => (
  <React.Fragment>
    {redraft(rawContentState, renderers, { blockStyleFn, customStyleFn })}
  </React.Fragment>
);

export default Content;
```