### PR TITLE
add unit test, rework render implementation

### DIFF
--- a/__tests__/__snapshots__/catIpsum.js.snap
+++ b/__tests__/__snapshots__/catIpsum.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<DocumentFragment>
+  <div>
+    <h2
+      class="paragraph"
+    >
+      Walk on keyboard 
+    </h2>
+  </div>
+  <div>
+    <div>
+      cat cat moo moo lick ears lick paws lay on arms while you're using the keyboard but kitty poochy, run off table persian cat jump eat fish, proudly present butt to human yet climb a tree, wait for a fireman jump to fireman then scratch his face. 
+    </div>
+  </div>
+  <div>
+    <h1>
+      <span
+        style="font-weight: bold; font-style: italic; text-decoration: underline;"
+      >
+        Pet my belly, you know you want to; seize the hand and shred it! 
+      </span>
+      snuggles up to shoulders or knees and purrs you to sleep. Pee in the shoe slap kitten brother with paw eat owner's food cats are a queer kind of folk. Proudly present butt to human. Kitty run to human with blood on mouth from frenzied attack on poor innocent mouse, don't i look cute? mark territory destroy house in 5 seconds or chase dog then run away but thinking longingly about tuna brine yet tickle my belly at your own peril i will pester for food when you're in the kitchen even if it's salad . 
+      <span
+        style="color: rgb(228, 23, 90);"
+      >
+        Chew iPad power cord kick up litter.
+      </span>
+    </h1>
+  </div>
+</DocumentFragment>
+`;

--- a/__tests__/__snapshots__/catIpsum.js.snap
+++ b/__tests__/__snapshots__/catIpsum.js.snap
@@ -4,16 +4,20 @@ exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div>
     <h2
-      class="paragraph"
+      class="align--center"
     >
       Walk on keyboard 
     </h2>
   </div>
+  <br />
   <div>
-    <div>
+    <div
+      class="paragraph"
+    >
       cat cat moo moo lick ears lick paws lay on arms while you're using the keyboard but kitty poochy, run off table persian cat jump eat fish, proudly present butt to human yet climb a tree, wait for a fireman jump to fireman then scratch his face. 
     </div>
   </div>
+  <br />
   <div>
     <h1>
       <span
@@ -29,5 +33,37 @@ exports[`renders correctly 1`] = `
       </span>
     </h1>
   </div>
+</DocumentFragment>
+`;
+
+exports[`renders correctly 2`] = `
+<DocumentFragment>
+  <br />
+  <br />
+  <div>
+    <div
+      class="paragraph align--center"
+    >
+      <span
+        style="font-size: 18px; line-height: 27px;"
+      >
+        "This is the nicest and most pleasant storage company I have ever dealt with. Not only is the staff exceptionally helpful, but they go out of their way to give the best customer service. The building is very clean. I was very impressed with the range of different units available. I highly recommend CatStorageMart for all your self storage and packing supplies need
+      </span>
+      s!"
+    </div>
+  </div>
+  <br />
+  <div>
+    <div
+      class="paragraph align--center"
+    >
+      <span
+        style="font-weight: bold;"
+      >
+        - Allie O., Google
+      </span>
+    </div>
+  </div>
+  <br />
 </DocumentFragment>
 `;

--- a/__tests__/catIpsum.js
+++ b/__tests__/catIpsum.js
@@ -1,0 +1,189 @@
+import React from 'react';
+import cx from 'classnames';
+import { render } from '@testing-library/react';
+import redraft from '../src';
+import { catIpsum } from './utils/raws';
+import createBlockRenderer from '../src/createBlockRenderer';
+import createStylesRenderer from '../src/createStyleRenderer';
+
+const HEADER_ONE = 'header-one';
+const HEADER_TWO = 'header-two';
+const HEADER_THREE = 'header-three';
+const HEADER_FOUR = 'header-four';
+const HEADER_FIVE = 'header-five';
+const HEADER_SIX = 'header-six';
+
+const UNORDERED_LIST_ITEM = 'unordered-list-item';
+const ORDERED_LIST_ITEM = 'ordered-list-item';
+
+const ATOMIC = 'atomic';
+const BLOCKQUOTE = 'blockquote';
+const UNSTYLED = 'unstyled';
+
+const BOLD = 'BOLD';
+const ITALIC = 'ITALIC';
+const UNDERLINE = 'UNDERLINE';
+const STRIKETHROUGH = 'STRIKETHROUGH';
+
+const TEXT_TRANSFORM = 'TEXT_TRANSFORM';
+
+const FONT_SIZE = 'FONT_SIZE';
+const FONT_FAMILY = 'FONT_FAMILY';
+const FONT_WEIGHT = 'FONT_WEIGHT';
+
+const COLOR = 'COLOR';
+const BACKGROUND_COLOR = 'BACKGROUND_COLOR';
+
+const inlineStyleMap = {
+  [STRIKETHROUGH]: {
+    textDecoration: 'line-through',
+  },
+  [UNDERLINE]: {
+    textDecoration: 'underline',
+  },
+  [BOLD]: {
+    fontWeight: 'bold',
+  },
+  [ITALIC]: {
+    fontStyle: 'italic',
+  },
+};
+
+const UL_WRAP = 'ul';
+const OL_WRAP = 'ol';
+
+const blockRenderMap = {
+  [HEADER_ONE]: {
+    element: 'h1',
+  },
+  [HEADER_TWO]: {
+    element: 'h2',
+  },
+  [HEADER_THREE]: {
+    element: 'h3',
+  },
+  [HEADER_FOUR]: {
+    element: 'h4',
+  },
+  [HEADER_FIVE]: {
+    element: 'h5',
+  },
+  [HEADER_SIX]: {
+    element: 'h6',
+  },
+  [UNORDERED_LIST_ITEM]: {
+    element: 'li',
+    wrapper: UL_WRAP,
+  },
+  [ORDERED_LIST_ITEM]: {
+    element: 'li',
+    wrapper: OL_WRAP,
+  },
+  [ATOMIC]: {
+    element: 'figure',
+  },
+  [BLOCKQUOTE]: {
+    element: 'blockquote',
+  },
+  [UNSTYLED]: {
+    element: 'div',
+  },
+};
+
+const applyInlineStyles = (draftInlineStyle) => {
+  const inlineStyle = {};
+
+  const fontSize = draftInlineStyle.find(value => value.startsWith(FONT_SIZE));
+  const fontWeight = draftInlineStyle.find(value => value.startsWith(FONT_WEIGHT));
+  const textTransform = draftInlineStyle.find(value => value.startsWith(TEXT_TRANSFORM));
+  const color = draftInlineStyle.find(value => value.startsWith(COLOR));
+  const backgroundColor = draftInlineStyle.find(value => value.startsWith(BACKGROUND_COLOR));
+
+  if (fontSize) {
+    const [, size] = fontSize.split(':');
+    const lineHeight = parseInt(size, 10) * 1.5;
+
+    inlineStyle.fontSize = `${size}px`;
+    inlineStyle.lineHeight = `${lineHeight}px`;
+  }
+
+  if (fontWeight) {
+    const [, weight] = fontWeight.split(':');
+
+    inlineStyle.fontWeight = weight;
+  }
+
+  if (textTransform) {
+    const [, transformation] = textTransform.split(':');
+
+    inlineStyle.textTransform = transformation;
+  }
+
+  if (color) {
+    const [, hex] = color.split(':');
+
+    inlineStyle.color = hex;
+  }
+
+  if (backgroundColor) {
+    const [, hex] = backgroundColor.split(':');
+
+    inlineStyle.backgroundColor = hex;
+  }
+
+  return inlineStyle;
+};
+
+const applyBlockStyles = (contentBlock) => {
+  const type = contentBlock.type;
+  const data = contentBlock.data;
+  const align = contentBlock.align;
+
+  return cx(
+    type === UNSTYLED && 'paragraph',
+    align && `${align}`,
+  );
+};
+
+const Inline = ({
+  children,
+  style,
+  key,
+}) => React.createElement('span', { key, style }, children);
+
+const BlockWrapper = (type, { key, className, style }, children) => React.createElement(
+  'div',
+  { key },
+  React.createElement(type, { key, style, className }, children),
+);
+
+const entities = {
+  LINK: (children, { href, target }) => <a href={href} target={target} rel={(target === '_blank') ? 'noopener noreferrer' : undefined}>{children}</a>,
+  FILE: (children, { href }) => <a href={href}>{children}</a>,
+};
+
+const renderers = {
+  styles: createStylesRenderer(Inline, inlineStyleMap),
+  blocks: createBlockRenderer(BlockWrapper, blockRenderMap),
+  entities,
+};
+
+const options = {
+  blockStyleFn: applyBlockStyles,
+  customStyleFn: applyInlineStyles,
+  cleanup: {
+    types: 'all',
+    after: 'all',
+  },
+};
+const Content = ({ rawContentState }) => (
+  <React.Fragment>
+    {redraft(rawContentState, renderers, options)}
+  </React.Fragment>
+);
+
+it('renders correctly', () => {
+  const component = render(<Content rawContentState={catIpsum} />)
+  /* component.debug(); */
+  expect(component.asFragment()).toMatchSnapshot();
+});

--- a/__tests__/catIpsum.js
+++ b/__tests__/catIpsum.js
@@ -2,10 +2,11 @@ import React from 'react';
 import cx from 'classnames';
 import { render } from '@testing-library/react';
 import redraft from '../src';
-import { catIpsum } from './utils/raws';
+import { catIpsum, reviewIpsum } from './utils/raws';
 import createBlockRenderer from '../src/createBlockRenderer';
 import createStylesRenderer from '../src/createStyleRenderer';
 
+// cleanup later
 const HEADER_ONE = 'header-one';
 const HEADER_TWO = 'header-two';
 const HEADER_THREE = 'header-three';
@@ -137,11 +138,11 @@ const applyInlineStyles = (draftInlineStyle) => {
 const applyBlockStyles = (contentBlock) => {
   const type = contentBlock.type;
   const data = contentBlock.data;
-  const align = contentBlock.align;
+  const align = data.align;
 
   return cx(
     type === UNSTYLED && 'paragraph',
-    align && `${align}`,
+    align && `align--${align}`,
   );
 };
 
@@ -153,7 +154,7 @@ const Inline = ({
 
 const BlockWrapper = (type, { key, className, style }, children) => React.createElement(
   'div',
-  { key },
+  null,
   React.createElement(type, { key, style, className }, children),
 );
 
@@ -165,17 +166,16 @@ const entities = {
 const renderers = {
   styles: createStylesRenderer(Inline, inlineStyleMap),
   blocks: createBlockRenderer(BlockWrapper, blockRenderMap),
+  emptyBlocks: (key) => (<br key={`${key}-line-break`}/>),
   entities,
 };
 
 const options = {
   blockStyleFn: applyBlockStyles,
   customStyleFn: applyInlineStyles,
-  cleanup: {
-    types: 'all',
-    after: 'all',
-  },
+  renderWithoutCleanup: true,
 };
+
 const Content = ({ rawContentState }) => (
   <React.Fragment>
     {redraft(rawContentState, renderers, options)}
@@ -184,6 +184,10 @@ const Content = ({ rawContentState }) => (
 
 it('renders correctly', () => {
   const component = render(<Content rawContentState={catIpsum} />)
-  /* component.debug(); */
+  expect(component.asFragment()).toMatchSnapshot();
+});
+
+it('renders correctly', () => {
+  const component = render(<Content rawContentState={reviewIpsum} />)
   expect(component.asFragment()).toMatchSnapshot();
 });

--- a/__tests__/utils/raws.js
+++ b/__tests__/utils/raws.js
@@ -1,3 +1,88 @@
+export const reviewIpsum = {
+  "blocks": [
+    {
+      "key": "db2mm",
+      "text": "",
+      "type": "unstyled",
+      "depth": 0,
+      "inlineStyleRanges": [],
+      "entityRanges": [],
+      "data": {
+        "align": "center"
+      }
+    },
+    {
+      "key": "6vm1t",
+      "text": "",
+      "type": "unstyled",
+      "depth": 0,
+      "inlineStyleRanges": [],
+      "entityRanges": [],
+      "data": {}
+    },
+    {
+      "key": "7odut",
+      "text": "\"This is the nicest and most pleasant storage company I have ever dealt with. Not only is the staff exceptionally helpful, but they go out of their way to give the best customer service. The building is very clean. I was very impressed with the range of different units available. I highly recommend CatStorageMart for all your self storage and packing supplies needs!\"",
+      "type": "unstyled",
+      "depth": 0,
+      "inlineStyleRanges": [
+        {
+          "offset": 0,
+          "length": 366,
+          "style": "FONT_FAMILY:primary"
+        },
+        {
+          "offset": 0,
+          "length": 366,
+          "style": "FONT_SIZE:18"
+        }
+      ],
+      "entityRanges": [],
+      "data": {
+        "align": "center"
+      }
+    },
+    {
+      "key": "affq9",
+      "text": "",
+      "type": "unstyled",
+      "depth": 0,
+      "inlineStyleRanges": [],
+      "entityRanges": [],
+      "data": {
+        "align": "center"
+      }
+    },
+    {
+      "key": "8l8ar",
+      "text": "- Allie O., Google",
+      "type": "unstyled",
+      "depth": 0,
+      "inlineStyleRanges": [
+        {
+          "offset": 0,
+          "length": 18,
+          "style": "BOLD"
+        }
+      ],
+      "entityRanges": [],
+      "data": {
+        "align": "center"
+      }
+    },
+    {
+      "key": "avpfv",
+      "text": "",
+      "type": "unstyled",
+      "depth": 0,
+      "inlineStyleRanges": [],
+      "entityRanges": [],
+      "data": {}
+    }
+  ],
+  "entityMap": {}
+};
+
 export const catIpsum = {
   "blocks": [
     {

--- a/__tests__/utils/raws.js
+++ b/__tests__/utils/raws.js
@@ -1,3 +1,77 @@
+export const catIpsum = {
+  "blocks": [
+    {
+      "key": "db2mm",
+      "text": "Walk on keyboard ",
+      "type": "header-two",
+      "depth": 0,
+      "inlineStyleRanges": [],
+      "entityRanges": [],
+      "data": {
+        align: 'center',
+      }
+    },
+    {
+      "key": "fnj8h",
+      "text": "",
+      "type": "unstyled",
+      "depth": 0,
+      "inlineStyleRanges": [],
+      "entityRanges": [],
+      "data": {}
+    },
+    {
+      "key": "13idm",
+      "text": "cat cat moo moo lick ears lick paws lay on arms while you're using the keyboard but kitty poochy, run off table persian cat jump eat fish, proudly present butt to human yet climb a tree, wait for a fireman jump to fireman then scratch his face. ",
+      "type": "unstyled",
+      "depth": 0,
+      "inlineStyleRanges": [],
+      "entityRanges": [],
+      "data": {}
+    },
+    {
+      "key": "4sp39",
+      "text": "",
+      "type": "unstyled",
+      "depth": 0,
+      "inlineStyleRanges": [],
+      "entityRanges": [],
+      "data": {}
+    },
+    {
+      "key": "a9eg1",
+      "text": "Pet my belly, you know you want to; seize the hand and shred it! snuggles up to shoulders or knees and purrs you to sleep. Pee in the shoe slap kitten brother with paw eat owner's food cats are a queer kind of folk. Proudly present butt to human. Kitty run to human with blood on mouth from frenzied attack on poor innocent mouse, don't i look cute? mark territory destroy house in 5 seconds or chase dog then run away but thinking longingly about tuna brine yet tickle my belly at your own peril i will pester for food when you're in the kitchen even if it's salad . Chew iPad power cord kick up litter.",
+      "type": "header-one",
+      "depth": 0,
+      "inlineStyleRanges": [
+        {
+          "offset": 0,
+          "length": 65,
+          "style": "BOLD"
+        },
+        {
+          "offset": 0,
+          "length": 65,
+          "style": "ITALIC"
+        },
+        {
+          "offset": 0,
+          "length": 65,
+          "style": "UNDERLINE"
+        },
+        {
+          "offset": 568,
+          "length": 36,
+          "style": "COLOR:#e4175a"
+        }
+      ],
+      "entityRanges": [],
+      "data": {}
+    }
+  ],
+  "entityMap": {}
+};
+
 export const raw = {
   entityMap: {
     0: {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,12 @@
     "lint": "eslint src",
     "prepublish": "npm run compile && npm test",
     "jest": "jest",
+    "jest:debug": "NODE_ENV=test node --inspect node_modules/.bin/jest --runInBand",
     "test": "npm run lint && npm run jest"
   },
-  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:nucle0tides/redraft.git"
@@ -36,10 +39,12 @@
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.4.0",
+    "@testing-library/react": "^11.0.4",
     "babel-eslint": "10.0.1",
     "babel-jest": "^24.0.0",
     "babel-plugin-array-includes": "^2.0.3",
     "chai": "^4.2.0",
+    "classnames": "^2.2.6",
     "draft-js": "^0.10.4",
     "eslint": "^5.16.0",
     "eslint-config-airbnb": "17.1.0",

--- a/src/createBlockRenderer.js
+++ b/src/createBlockRenderer.js
@@ -22,6 +22,7 @@ const getBlock = (element, wrapper) => (
   const blockKey = getKey(props, key);
   delete props.depth;
   delete props.keys;
+  if (!props.data || (props.data.length && !props.data.some(item => !!item))) delete props.data;
   return wrapper(
     element,
     Object.assign({}, props, { key: blockKey }),

--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -9,6 +9,7 @@ const defaultOptions = {
   blockFallback: 'unstyled',
   blockStyleFn: undefined,
   customStyleFn: undefined,
+  renderWithoutCleanup: false,
 };
 
 export default defaultOptions;

--- a/src/render.js
+++ b/src/render.js
@@ -47,7 +47,9 @@ export const renderNode = (
     }
   });
   if (node.style && inlineRenderers[node.style]) {
-    return inlineRenderers[node.style](checkJoin(children, options), { key: keyGenerator() });
+    return inlineRenderers[node.style](
+      checkJoin(children, options), { key: keyGenerator() },
+    )(options.customStyleFn);
   }
   if (node.entity !== null) {
     const entity = entityMap[node.entity];
@@ -167,7 +169,8 @@ const renderBlocks = (
   const Parser = new RawParser({ flat: !!stylesRenderer });
   blocks.forEach((block) => {
     if (options.blockStyleFn && typeof options.blockStyleFn === 'function') {
-      className = options.blockStyleFn(block);
+      const blockClass = options.blockStyleFn(block);
+      className = blockClass && blockClass.length ? blockClass : undefined;
     }
     if (checkCleanup(block, prevType, options)) {
       // Set the split flag if enabled

--- a/src/render.js
+++ b/src/render.js
@@ -49,7 +49,7 @@ export const renderNode = (
   if (node.style && inlineRenderers[node.style]) {
     return inlineRenderers[node.style](
       checkJoin(children, options), { key: keyGenerator() },
-    )(options.customStyleFn);
+    );
   }
   if (node.entity !== null) {
     const entity = entityMap[node.entity];
@@ -122,7 +122,7 @@ const byDepth = (blocks) => {
  */
 const renderGroup = (group, blockRenderers, rendered, params, options) => {
   const {
-    prevType: type, prevDepth: depth, prevKeys: keys, prevData: data, className,
+    type, depth, key, keys, data, className,
   } = params;
   // in case current group is empty it should not be rendered
   if (group.length === 0) {
@@ -132,12 +132,12 @@ const renderGroup = (group, blockRenderers, rendered, params, options) => {
   if (renderCb) {
     const props = {
       depth,
+      key,
       keys,
+      data,
       className: className && className.length ? className : undefined,
     };
-    if (data && data.some(item => !!item)) {
-      props.data = data;
-    }
+
     rendered.push(renderCb(group, props));
     return;
   }
@@ -169,8 +169,7 @@ const renderBlocks = (
   const Parser = new RawParser({ flat: !!stylesRenderer });
   blocks.forEach((block) => {
     if (options.blockStyleFn && typeof options.blockStyleFn === 'function') {
-      const blockClass = options.blockStyleFn(block);
-      className = blockClass && blockClass.length ? blockClass : undefined;
+      className = options.blockStyleFn(block);
     }
     if (checkCleanup(block, prevType, options)) {
       // Set the split flag if enabled
@@ -197,7 +196,7 @@ const renderBlocks = (
         blockRenderers,
         rendered,
         {
-          prevType, prevDepth, prevKeys, prevData, className,
+          type: prevType, depth: prevDepth, keys: prevKeys, data: prevData, className,
         },
         options,
       );
@@ -237,10 +236,87 @@ const renderBlocks = (
     blockRenderers,
     rendered,
     {
-      prevType, prevDepth, prevKeys, prevData, className,
+      type: prevType, depth: prevDepth, keys: prevKeys, data: prevData, className,
     },
     options,
   );
+  return checkJoin(rendered, options);
+};
+
+// come up w/ a better name/way of handling this
+// don't particularly care to rework the entire lib and tests right now
+const renderBlocksWithoutCleanup = (
+  blocks,
+  inlineRenderers = {},
+  blockRenderers = {},
+  entityRenderers = {},
+  stylesRenderer,
+  emptyBlockRenderer,
+  entityMap = {},
+  userOptions = {},
+) => {
+  const options = Object.assign({}, defaultOptions, userOptions);
+  const rendered = [];
+
+  let className;
+  const Parser = new RawParser({ flat: !!stylesRenderer });
+
+  blocks.forEach((block, idx) => {
+    // if block is empty, render a <br />
+    if (emptyBlockRenderer && block.type === 'unstyled' && (!block.text || !block.text.trim().length)) {
+      const { key } = block;
+      rendered.push(emptyBlockRenderer(key));
+      return;
+    }
+
+    // otherwise, render
+    if (options.blockStyleFn && typeof options.blockStyleFn === 'function') {
+      const blockClass = options.blockStyleFn(block);
+      className = blockClass && blockClass.length ? blockClass : undefined;
+    }
+
+    const node = Parser.parse(block);
+    const renderedNode = renderNode(
+      node,
+      inlineRenderers,
+      entityRenderers,
+      stylesRenderer,
+      entityMap,
+      options,
+      getKeyGenerator(),
+    );
+
+    if (block.children) {
+      const childNodes = children.map(
+        renderBlocks(
+          block.children,
+          inlineRenderers,
+          blockRenderers,
+          entityRenderers,
+          stylesRenderer,
+          entityMap,
+          options,
+        ),
+      );
+      renderedNode.push(children);
+    }
+
+    const { type, data, key, depth } = block;
+    renderGroup(
+      [renderedNode],
+      blockRenderers,
+      rendered,
+      {
+        type,
+        data,
+        key: `${key}-${idx}-${block.type}`,
+        depth,
+        className
+      },
+      options,
+    );
+  });
+
   return checkJoin(rendered, options);
 };
 
@@ -261,12 +337,28 @@ export const render = (raw, renderers = {}, options = {}) => {
     blocks: blockRenderers,
     entities: entityRenderers,
     styles: stylesRenderer,
+    emptyBlocks: emptyBlockRenderer,
     decorators,
   } = renderers;
   // If decorators are present, they are maped with the blocks array
   const blocksWithDecorators = decorators ? withDecorators(raw, decorators, options) : raw.blocks;
   // Nest blocks by depth
   const blocks = byDepth(blocksWithDecorators);
+
+  // figure out a better way to do this
+  // or just redo all the tests since you're only using this for work anyway
+  if (options.renderWithoutCleanup) {
+    return renderBlocksWithoutCleanup(
+      blocks,
+      inlineRenderers,
+      blockRenderers,
+      entityRenderers,
+      stylesRenderer,
+      emptyBlockRenderer,
+      raw.entityMap,
+      options,
+    );
+  }
   return renderBlocks(
     blocks,
     inlineRenderers,

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,6 +24,13 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
+"@babel/code-frame@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
+  integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
+
 "@babel/core@^7.1.0", "@babel/core@^7.4.0":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.5.tgz#081f97e8ffca65a9b4b0fdc7e274e703f000c06a"
@@ -198,6 +205,11 @@
   dependencies:
     "@babel/types" "^7.4.4"
 
+"@babel/helper-validator-identifier@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
+  integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
+
 "@babel/helper-wrap-function@^7.1.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz#c4e0012445769e2815b55296ead43a958549f6fa"
@@ -221,6 +233,15 @@
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
+  integrity sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    chalk "^2.0.0"
     js-tokens "^4.0.0"
 
 "@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.4.4", "@babel/parser@^7.4.5":
@@ -635,6 +656,21 @@
     pirates "^4.0.0"
     source-map-support "^0.5.9"
 
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz#02c3029743150188edeb66541195f54600278419"
+  integrity sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.4.5":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
@@ -814,6 +850,43 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
+"@jest/types@^26.5.2":
+  version "26.5.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.5.2.tgz#44c24f30c8ee6c7f492ead9ec3f3c62a5289756d"
+  integrity sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
+"@testing-library/dom@^7.24.2":
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.24.5.tgz#862124eec8c37ad184716379f09742476b23815d"
+  integrity sha512-oyOp8R2rhmnkOjgrySb4iYc2q73dzvQUAGddpbmicGJdCf4jkLmf5U9zOyobLMLWXbIHHK4UUHHjDTH8tSPLsA==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.10.3"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.1"
+    pretty-format "^26.4.2"
+
+"@testing-library/react@^11.0.4":
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.0.4.tgz#c84082bfe1593d8fcd475d46baee024452f31dee"
+  integrity sha512-U0fZO2zxm7M0CB5h1+lh31lbAwMSmDMEMGpMT3BUPJwIjDEKYWOV4dx7lb3x2Ue0Pyt77gmz/VropuJnSz/Iew==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    "@testing-library/dom" "^7.24.2"
+
+"@types/aria-query@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
+  integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
+
 "@types/babel__core@^7.1.0":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.2.tgz#608c74f55928033fce18b99b213c16be4b3d114f"
@@ -860,13 +933,37 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821"
+  integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
+  dependencies:
+    "@types/istanbul-lib-report" "*"
+
+"@types/node@*":
+  version "14.11.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.8.tgz#fe2012f2355e4ce08bca44aeb3abbb21cf88d33f"
+  integrity sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
 
+"@types/yargs-parser@*":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
+  integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
+
 "@types/yargs@^12.0.2", "@types/yargs@^12.0.9":
   version "12.0.12"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.12.tgz#45dd1d0638e8c8f153e87d296907659296873916"
+
+"@types/yargs@^15.0.0":
+  version "15.0.8"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.8.tgz#7644904cad7427eb704331ea9bf1ee5499b82e23"
+  integrity sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 abab@^2.0.0:
   version "2.0.0"
@@ -941,11 +1038,23 @@ ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
 
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -977,6 +1086,14 @@ aria-query@^3.0.0:
   dependencies:
     ast-types-flow "0.0.7"
     commander "^2.11.0"
+
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -1260,6 +1377,14 @@ chalk@^2.1.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^4.0.0, chalk@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -1303,6 +1428,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
@@ -1342,9 +1472,21 @@ color-convert@^1.9.0:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 combined-stream@1.0.6:
   version "1.0.6"
@@ -1411,6 +1553,11 @@ core-js-compat@^3.1.1:
 core-js-pure@3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.4.tgz#5fa17dc77002a169a3566cc48dc774d2e13e3769"
+
+core-js-pure@^3.0.0:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
+  integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -1569,6 +1716,11 @@ doctrine@^3.0.0:
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.1:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz#b06d059cdd4a4ad9a79275f9d414a5c126241166"
+  integrity sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
 
 domexception@^1.0.1:
   version "1.0.1"
@@ -2198,6 +2350,11 @@ har-validator@~5.1.0:
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-symbols@^1.0.0:
   version "1.0.0"
@@ -3717,6 +3874,16 @@ pretty-format@^24.8.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
+pretty-format@^26.4.2:
+  version "26.5.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.5.2.tgz#5d896acfdaa09210683d34b6dc0e6e21423cd3e1"
+  integrity sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==
+  dependencies:
+    "@jest/types" "^26.5.2"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
 private@^0.1.6:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -3797,6 +3964,11 @@ react-dom@^16.8.4:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.6"
+
+react-is@^16.12.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.8.6"
@@ -3889,6 +4061,11 @@ regenerate@^1.4.0:
 regenerator-runtime@^0.13.2:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+
+regenerator-runtime@^0.13.4:
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
 regenerator-transform@^0.14.0:
   version "0.14.0"
@@ -4381,6 +4558,13 @@ supports-color@^6.1.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
 
 symbol-tree@^3.2.2:
   version "3.2.2"


### PR DESCRIPTION
add 
- `emptyBlocks` renderer
- `renderWithoutCleanup` option which basically skips the "legacy" renderer and uses my own.

`renderWithoutCleanup` option added as an easy way to get around trying to rework the entire library. I may either rip apart the entire library and rework it in my own image.